### PR TITLE
Fix ISO tag for 'Basic Latin' script group

### DIFF
--- a/code/scriptGroups.js
+++ b/code/scriptGroups.js
@@ -361,7 +361,7 @@ function findScriptGroup ( charNum ) {
 function findScriptISO ( charNum ) { 
 	// output: returns the iso code of the script group in which charNum falls
 	// charNum: a decimal number representing the code point of the character in question
-	if (charNum < 128) { return 'Basic Latin' }
+	if (charNum < 128) { return 'latn' }
 	var i=1
 	while ( i<scriptGroups.length && charNum > scriptGroups[i][0] ) i++
 	if ( i === scriptGroups.length ) { return( sNotAChar ) }


### PR DESCRIPTION
Hello! Thanks for the great tools :) 

This PR fixes the ISO tag for the 'Basic Latin' script group; before, the function special case returned the name of the script group instead. This is a partial fix for r12a/uniview#15 and r12a/uniview#16.